### PR TITLE
Fix for schema URLs modified by security proxies.

### DIFF
--- a/parser.ts
+++ b/parser.ts
@@ -2,7 +2,7 @@
  * Parse a vega schema url into library and version.
  */
 export default function(url: string) {
-    const regex = /\/schema\/([\w-]+)\/([\w\.\-]+)\.json$/g;
+    const regex = /schema\/([\w-]+)\/([\w\.\-]+)\.json$/g;
     const [library, version] = regex.exec(url)!.slice(1, 3);
     return {library: library as 'vega' | 'vega-lite', version};
 }

--- a/test.ts
+++ b/test.ts
@@ -17,3 +17,9 @@ test('parses url with alpha correctly', function () {
     expect(parsed.library).toBe('vega-lite');
     expect(parsed.version).toBe('v2.0.0-alpha.0');
 });
+
+test('parses proxied url correctly', function () {
+   const parsed = parser('https://www.proxy.net/,ProxInfo=.abc123FgHi789,SSL+schema/vega/v2.5.2.json');
+   expect(parsed.library).toBe('vega');
+   expect(parsed.version).toBe('v2.5.2');
+});


### PR DESCRIPTION
I am using vega within a strictly secured network enclave. This
includes an appliance in the middle that rewrites all URLs
such that they go through a proxy.  This even includes modification
of schema URLs that are embedded in application source code.

This change allows vega-schema-url-parser to work in these cases.
It simply removes the requirement that schema has to be immediately
prefixed by a '/'.